### PR TITLE
Machine account data accessors for Core/Cases.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ NCS Navigator Configuration gem history
 0.3.2
 -----
 
+- New optional Core attribute: machine_account_password.  (#11)
+
 0.3.1
 -----
 

--- a/lib/ncs_navigator/configuration.rb
+++ b/lib/ncs_navigator/configuration.rb
@@ -240,6 +240,11 @@ module NcsNavigator
     configuration_attribute :core_uri, 'Core', 'uri', URI, :required => true
 
     ##
+    # Machine account for Cases.
+    configuration_attribute :core_machine_account_password, 'Core',
+      'machine_account_password', String
+
+    ##
     # The address from which mail sent by Core will appear to come.
     configuration_attribute :core_mail_from, 'Core', 'mail_from', String,
       :default => 'cases@navigator.example.edu'

--- a/spec/ncs_navigator/configuration_spec.rb
+++ b/spec/ncs_navigator/configuration_spec.rb
@@ -440,6 +440,12 @@ module NcsNavigator
         end
       end
 
+      describe '#core_machine_account_password' do
+        it 'is the configured value' do
+          everything.core_machine_account_password.should == 'foobar'
+        end
+      end
+
       describe '#core' do
         it 'exposes all the raw values in the Staff Portal section' do
           everything.core['uri'].should == "https://ncsnavigator.greaterchicagoncs.org/"

--- a/spec/ncs_navigator/everything.ini
+++ b/spec/ncs_navigator/everything.ini
@@ -22,6 +22,7 @@ mail_from = "staffportal@greaterchicagoncs.org"
 [Core]
 uri = "https://ncsnavigator.greaterchicagoncs.org/"
 mail_from = "ncs-navigator@greaterchicagoncs.org"
+machine_account_password = "foobar"
 
 [PSC]
 uri = "https://calendar.greaterchicagoncs.org/"


### PR DESCRIPTION
Cases needs a machine account to send changes to PSC.

This pull request adds a new configuration directive, `machine_accounts_file`, under the `[Core]` section.  It also adds a `core_machine_accounts` reader that returns a username => user data block map.
