### PR TITLE
Add configuration attributes for Cases' merge conflict notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ NCS Navigator Configuration gem history
 0.3.3
 -----
 
+- New optional Core attribute: conflict_email_recipients.  (#12)
+
 0.3.2
 -----
 

--- a/lib/ncs_navigator/configuration.rb
+++ b/lib/ncs_navigator/configuration.rb
@@ -250,6 +250,11 @@ module NcsNavigator
       :default => 'cases@navigator.example.edu'
 
     ##
+    # When a merge conflict occurs in Cases, send emails to these addresses.
+    configuration_attribute :core_conflict_email_recipients, 'Core',
+      'conflict_email_recipients', Array, :default => []
+
+    ##
     # The root URI for the PSC deployment in this instance of
     # the suite.
     configuration_attribute :psc_uri, 'PSC', 'uri', URI, :required => true

--- a/spec/ncs_navigator/configuration_spec.rb
+++ b/spec/ncs_navigator/configuration_spec.rb
@@ -446,6 +446,15 @@ module NcsNavigator
         end
       end
 
+      describe '#core_conflict_email_recipients' do
+        it 'is the configured value' do
+          everything.core_conflict_email_recipients.should == [
+            'Foo Bar <foobar@example.edu>',
+            'Baz Quux <bazquux@example.edu>'
+          ]
+        end
+      end
+
       describe '#core' do
         it 'exposes all the raw values in the Staff Portal section' do
           everything.core['uri'].should == "https://ncsnavigator.greaterchicagoncs.org/"

--- a/spec/ncs_navigator/everything.ini
+++ b/spec/ncs_navigator/everything.ini
@@ -23,6 +23,7 @@ mail_from = "staffportal@greaterchicagoncs.org"
 uri = "https://ncsnavigator.greaterchicagoncs.org/"
 mail_from = "ncs-navigator@greaterchicagoncs.org"
 machine_account_password = "foobar"
+conflict_email_recipients="Foo Bar <foobar@example.edu>, Baz Quux <bazquux@example.edu>"
 
 [PSC]
 uri = "https://calendar.greaterchicagoncs.org/"


### PR DESCRIPTION
When Cases detects a merge conflict, it will send email notifications to people who can deal with it.  Those email addresses should be set in `navigator.ini`.

Proposed attributes:

```
[Core]
conflict_email_recipients="Foo Bar <foobar@example.edu>, Baz Quux <bazquux@example.edu>"
```
