### PR TITLE
Make sc_id, recruitment_type_id, sampling_units_file and core uri optional.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ NCS Navigator Configuration gem history
 
 - Make sc_id optional.  (#16)
 
+- Make sampling_units_file optional.  (#17)
+
 0.3.2
 -----
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 NCS Navigator Configuration gem history
 =======================================
 
-0.3.3
+0.4.0
 -----
 
 - New optional Core attribute: conflict_email_recipients.  (#12)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ NCS Navigator Configuration gem history
 
 - Make sampling_units_file optional.  (#17)
 
+- Make recruitement_type_id optional.  (#18)
 0.3.2
 -----
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,10 @@ NCS Navigator Configuration gem history
 
 - Make sampling_units_file optional.  (#17)
 
-- Make recruitement_type_id optional.  (#18)
+- Make recruitment_type_id optional.  (#18)
+
+- Make core uri optional.  (#19)
+
 0.3.2
 -----
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ NCS Navigator Configuration gem history
 
 - New optional Core attribute: machine_account_username.  (#14)
 
+- Make sc_id optional.  (#16)
+
 0.3.2
 -----
 

--- a/lib/ncs_navigator/configuration.rb
+++ b/lib/ncs_navigator/configuration.rb
@@ -166,8 +166,7 @@ module NcsNavigator
     # @macro [attach] configuration_attribute
     #   Read from the `[$2]` section, key `$3`.
     #   @return [$4]
-    configuration_attribute :study_center_id, 'Study Center', 'sc_id', String,
-      :required => true
+    configuration_attribute :study_center_id, 'Study Center', 'sc_id', String
 
     alias :sc_id :study_center_id
 

--- a/lib/ncs_navigator/configuration.rb
+++ b/lib/ncs_navigator/configuration.rb
@@ -376,12 +376,13 @@ module NcsNavigator
       areas = {}
       ssus = {}
 
-      unless sampling_units_file.readable?
+      if sampling_units_file && !sampling_units_file.readable?
         raise Error.new("Could not read sampling units CSV #{sampling_units_file}")
       end
 
       strip_ws = lambda { |h| h.nil? ? nil : h.strip }
 
+      return [] unless sampling_units_file
       faster_csv_class.foreach(sampling_units_file,
         :headers => true, :encoding => 'utf-8',
         :converters => [strip_ws], :header_converters => [strip_ws]

--- a/lib/ncs_navigator/configuration.rb
+++ b/lib/ncs_navigator/configuration.rb
@@ -202,8 +202,7 @@ module NcsNavigator
     #
     # The format is described in the comments in the
     # {file:sample_configuration.ini sample INI}.
-    configuration_attribute :sampling_units_file, 'Study Center', 'sampling_units_file', Pathname,
-      :required => true
+    configuration_attribute :sampling_units_file, 'Study Center', 'sampling_units_file', Pathname
 
     ##
     # The image that should appear on the left side of the footer in

--- a/lib/ncs_navigator/configuration.rb
+++ b/lib/ncs_navigator/configuration.rb
@@ -234,7 +234,7 @@ module NcsNavigator
     ##
     # The root URI for the NCS Navigator Core deployment in this instance of
     # the suite.
-    configuration_attribute :core_uri, 'Core', 'uri', URI, :required => true
+    configuration_attribute :core_uri, 'Core', 'uri', URI
 
     ##
     # Machine account for Cases.

--- a/lib/ncs_navigator/configuration.rb
+++ b/lib/ncs_navigator/configuration.rb
@@ -174,8 +174,7 @@ module NcsNavigator
     # The recruitment strategy for this study center. The acceptable
     # values are those from the code list `recruit_type_cl1` in the
     # MDES.
-    configuration_attribute :recruitment_type_id, 'Study Center', 'recruitment_type_id', String,
-      :required => true
+    configuration_attribute :recruitment_type_id, 'Study Center', 'recruitment_type_id', String
 
     ##
     # A short, human-readable name or abbreviation for the Study

--- a/lib/ncs_navigator/configuration/version.rb
+++ b/lib/ncs_navigator/configuration/version.rb
@@ -1,5 +1,5 @@
 module NcsNavigator
   class Configuration
-    VERSION = '0.3.3.pre'
+    VERSION = '0.4.0.pre'
   end
 end

--- a/spec/ncs_navigator/configuration_spec.rb
+++ b/spec/ncs_navigator/configuration_spec.rb
@@ -54,6 +54,7 @@ module NcsNavigator
     let(:everything_file) { File.expand_path('../everything.ini', __FILE__) }
 
     # input_hash should be kept minimally valid
+    # ToDo: update minimally valid input_hash with required fields only.
     let(:input_hash) {
       {
         'Study Center' => {
@@ -63,9 +64,6 @@ module NcsNavigator
         },
         'Staff Portal' => {
           'uri' => 'https://sp.example.edu/'
-        },
-        'Core' => {
-          'uri' => 'https://ncsn.example.edu/',
         },
         'PSC' => {
           'uri' => 'https://psc.example.edu/'

--- a/spec/ncs_navigator/configuration_spec.rb
+++ b/spec/ncs_navigator/configuration_spec.rb
@@ -179,10 +179,10 @@ module NcsNavigator
         everything.sampling_units_file.should be_a(Pathname)
       end
 
-      it 'is required' do
+      it 'is not required' do
         input_hash['Study Center'].delete 'sampling_units_file'
         lambda { from_hash }.
-          should raise_error "Please set a value for [Study Center]: sampling_units_file"
+          should_not raise_error
       end
     end
 

--- a/spec/ncs_navigator/configuration_spec.rb
+++ b/spec/ncs_navigator/configuration_spec.rb
@@ -124,10 +124,10 @@ module NcsNavigator
         from_hash.recruitment_type_id.should == '234'
       end
 
-      it 'is mandatory' do
+      it 'is not mandatory' do
         input_hash['Study Center'].delete 'recruitment_type_id'
         lambda { from_hash }.
-          should raise_error("Please set a value for [Study Center]: recruitment_type_id")
+          should_not raise_error
       end
     end
 

--- a/spec/ncs_navigator/configuration_spec.rb
+++ b/spec/ncs_navigator/configuration_spec.rb
@@ -71,6 +71,18 @@ module NcsNavigator
       }
     }
     let(:from_hash) { Configuration.new(input_hash) }
+    let(:minimum_valid_hash) {
+      {
+        'Staff Portal' => {
+          'uri' => 'https://sp.example.edu/'
+        },
+        'PSC' => {
+          'uri' => 'https://psc.example.edu/'
+        }
+      }
+    }
+    let(:from_minimum_valid_hash) { Configuration.new(minimum_valid_hash) }
+
 
     describe '#initialize' do
       describe 'from an INI file' do
@@ -106,15 +118,14 @@ module NcsNavigator
       end
 
       it 'is not mandatory' do
-        input_hash['Study Center'].delete 'sc_id'
-        lambda { from_hash }.
+        lambda { from_minimum_valid_hash }.
           should_not raise_error
       end
     end
 
     describe '#recruitment_type_id' do
       it 'reflects the configured value' do
-        from_hash.recruitment_type_id.should == '3'
+        everything.recruitment_type_id.should == '1'
       end
 
       it 'is always a string' do
@@ -123,8 +134,7 @@ module NcsNavigator
       end
 
       it 'is not mandatory' do
-        input_hash['Study Center'].delete 'recruitment_type_id'
-        lambda { from_hash }.
+        lambda { from_minimum_valid_hash }.
           should_not raise_error
       end
     end
@@ -178,62 +188,52 @@ module NcsNavigator
       end
 
       it 'is not required' do
-        input_hash['Study Center'].delete 'sampling_units_file'
-        lambda { from_hash }.
+        lambda { from_minimum_valid_hash }.
           should_not raise_error
       end
     end
 
     describe '#sampling_unit_areas' do
-      subject { everything.sampling_unit_areas }
-
-      it 'has the right number' do
-        subject.size.should == 2
+      describe 'when no sampling_unit_file' do
+        it 'is an empty array' do
+          from_minimum_valid_hash.sampling_unit_areas.should be_empty
+        end
       end
 
-      describe 'an individual area' do
-        let(:area) { subject.sort_by { |a| a.name }.last }
+      describe 'when sampling_units_file is present' do
+        subject { everything.sampling_unit_areas }
 
-        it 'has a name' do
-          area.name.should == 'Uptown'
+        it 'has the right number' do
+          subject.size.should == 2
         end
 
-        it 'has the right number of SSUs' do
-          area.secondary_sampling_units.size.should == 2
-        end
+        describe 'an individual area' do
+          let(:area) { subject.sort_by { |a| a.name }.last }
 
-        it 'has the right PSU' do
-          area.primary_sampling_unit.id.should == '204'
+          it 'has a name' do
+            area.name.should == 'Uptown'
+          end
+
+          it 'has the right number of SSUs' do
+            area.secondary_sampling_units.size.should == 2
+          end
+
+          it 'has the right PSU' do
+            area.primary_sampling_unit.id.should == '204'
+          end
         end
       end
     end
 
     describe '#primary_sampling_units' do
-      subject { everything.primary_sampling_units }
-
-      it 'has the right number' do
-        subject.size.should == 1
-      end
-
-      describe 'an individual PSU' do
-        let(:psu) { subject.first }
-
-        it 'has the correct ID' do
-          psu.id.should == '204'
-        end
-
-        it 'has the correct SSUs' do
-          psu.secondary_sampling_units.collect(&:id).should == %w(One Two Three)
+      describe 'when no sampling_unit_file' do
+        it 'is an empty array' do
+          from_minimum_valid_hash.primary_sampling_units.should be_empty
         end
       end
 
-      context 'without Areas and SSUs' do
-        before do
-          input_hash['Study Center']['sampling_units_file'] =
-            File.expand_path('../no_ssus.csv', __FILE__)
-        end
-
-        subject { from_hash.primary_sampling_units }
+      describe 'when sampling_units_file is present' do
+        subject { everything.primary_sampling_units }
 
         it 'has the right number' do
           subject.size.should == 1
@@ -246,102 +246,135 @@ module NcsNavigator
             psu.id.should == '204'
           end
 
-          it 'has no Areas' do
-            psu.should have(0).sampling_unit_areas
+          it 'has the correct SSUs' do
+            psu.secondary_sampling_units.collect(&:id).should == %w(One Two Three)
+          end
+        end
+
+        context 'without Areas and SSUs' do
+          before do
+            input_hash['Study Center']['sampling_units_file'] =
+              File.expand_path('../no_ssus.csv', __FILE__)
           end
 
-          it 'has no SSUs' do
-            psu.should have(0).secondary_sampling_units
+          subject { from_hash.primary_sampling_units }
+
+          it 'has the right number' do
+            subject.size.should == 1
+          end
+
+          describe 'an individual PSU' do
+            let(:psu) { subject.first }
+
+            it 'has the correct ID' do
+              psu.id.should == '204'
+            end
+
+            it 'has no Areas' do
+              psu.should have(0).sampling_unit_areas
+            end
+
+            it 'has no SSUs' do
+              psu.should have(0).secondary_sampling_units
+            end
           end
         end
       end
     end
 
     describe '#secondary_sampling_units' do
-      subject { everything.secondary_sampling_units }
-
-      it 'has the right number' do
-        subject.size.should == 3
-      end
-
-      describe 'an individual SSU' do
-        let(:ssu) { subject.sort_by { |ssu| ssu.id }.first }
-
-        it 'has the correct ID' do
-          ssu.id.should == 'One'
-        end
-
-        it 'has the correct name' do
-          ssu.name.should == 'West Side'
-        end
-
-        it 'has the correct area' do
-          ssu.area.name.should == 'Uptown'
-        end
-
-        it 'has the same area as another SSU in the same area' do
-          ssu.area.should eql(subject.find { |ssu| ssu.name == 'West Side' }.area)
-        end
-
-        it 'has the correct PSU' do
-          ssu.primary_sampling_unit.id.should == '204'
-        end
-
-        it 'has the correct TSUs' do
-          ssu.should have(1).tertiary_sampling_units
-        end
-
-        describe 'a TSU' do
-          let(:tsu) { ssu.tertiary_sampling_units.first }
-
-          it 'has a name' do
-            tsu.name.should == 'Center'
-          end
-
-          it 'has an ID' do
-            tsu.id.should == '1-1'
-          end
+      describe 'when no sampling_unit_file' do
+        it 'is an empty array' do
+          from_minimum_valid_hash.secondary_sampling_units.should be_empty
         end
       end
 
-      context 'without TSUs' do
-        before do
-          input_hash['Study Center']['sampling_units_file'] =
-            File.expand_path('../no_tsus.csv', __FILE__)
-        end
-
-        subject { from_hash.secondary_sampling_units }
+      describe 'when sampling_units_file is present' do
+        subject { everything.secondary_sampling_units }
 
         it 'has the right number' do
           subject.size.should == 3
         end
 
         describe 'an individual SSU' do
-          let(:ssu) { subject.first }
+          let(:ssu) { subject.sort_by { |ssu| ssu.id }.first }
 
-          it 'has no TSUs' do
-            ssu.should have(0).tertiary_sampling_units
+          it 'has the correct ID' do
+            ssu.id.should == 'One'
           end
-        end
-      end
 
-      context 'with extra whitespace' do
-        before do
-          input_hash['Study Center']['sampling_units_file'] =
-            File.expand_path('../spaces.csv', __FILE__)
-        end
-
-        subject { from_hash.secondary_sampling_units }
-
-        it 'has the right number' do
-          subject.size.should == 3
-        end
-
-        describe 'an individual SSU' do
-          let(:ssu) { subject.detect { |s| s.id == 'One' } }
-
-          it 'has the name' do
+          it 'has the correct name' do
             ssu.name.should == 'West Side'
+          end
+
+          it 'has the correct area' do
+            ssu.area.name.should == 'Uptown'
+          end
+
+          it 'has the same area as another SSU in the same area' do
+            ssu.area.should eql(subject.find { |ssu| ssu.name == 'West Side' }.area)
+          end
+
+          it 'has the correct PSU' do
+            ssu.primary_sampling_unit.id.should == '204'
+          end
+
+          it 'has the correct TSUs' do
+            ssu.should have(1).tertiary_sampling_units
+          end
+
+          describe 'a TSU' do
+            let(:tsu) { ssu.tertiary_sampling_units.first }
+
+            it 'has a name' do
+              tsu.name.should == 'Center'
+            end
+
+            it 'has an ID' do
+              tsu.id.should == '1-1'
+            end
+          end
+        end
+
+        context 'without TSUs' do
+          before do
+            input_hash['Study Center']['sampling_units_file'] =
+              File.expand_path('../no_tsus.csv', __FILE__)
+          end
+
+          subject { from_hash.secondary_sampling_units }
+
+          it 'has the right number' do
+            subject.size.should == 3
+          end
+
+          describe 'an individual SSU' do
+            let(:ssu) { subject.first }
+
+            it 'has no TSUs' do
+              ssu.should have(0).tertiary_sampling_units
+            end
+          end
+        end
+
+        context 'with extra whitespace' do
+          before do
+            input_hash['Study Center']['sampling_units_file'] =
+              File.expand_path('../spaces.csv', __FILE__)
+          end
+
+          subject { from_hash.secondary_sampling_units }
+
+          it 'has the right number' do
+            subject.size.should == 3
+          end
+
+          describe 'an individual SSU' do
+            let(:ssu) { subject.detect { |s| s.id == 'One' } }
+
+            it 'has the name' do
+              ssu.name.should == 'West Side'
+            end
           end
         end
       end

--- a/spec/ncs_navigator/configuration_spec.rb
+++ b/spec/ncs_navigator/configuration_spec.rb
@@ -107,10 +107,10 @@ module NcsNavigator
         from_hash.study_center_id.should == '234'
       end
 
-      it 'is mandatory' do
+      it 'is not mandatory' do
         input_hash['Study Center'].delete 'sc_id'
         lambda { from_hash }.
-          should raise_error("Please set a value for [Study Center]: sc_id")
+          should_not raise_error
       end
     end
 


### PR DESCRIPTION
Make sc_id, recruitment_type_id, sampling_units_file and core_uri optional. This change was needed for the WROC setup where navigator.ini for Ops doesn't have all of above variables.
