### PR TITLE
MDES version accessor for Pancakes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ NCS Navigator Configuration gem history
 0.4.1
 -----
 
+- New attribute for Pancakes: mdes_version.
+
 0.4.0
 -----
 

--- a/lib/ncs_navigator/configuration.rb
+++ b/lib/ncs_navigator/configuration.rb
@@ -46,7 +46,7 @@ module NcsNavigator
 
     ######
 
-    APPLICATION_SECTIONS = ['Staff Portal', 'Core', 'PSC']
+    APPLICATION_SECTIONS = ['Staff Portal', 'Core', 'PSC', 'Pancakes']
 
     class << self
       ##
@@ -232,6 +232,10 @@ module NcsNavigator
       :default => 'ops@navigator.example.edu'
 
     ##
+    # The MDES version for Pancakes.
+    configuration_attribute :pancakes_mdes_version, 'Pancakes', 'mdes_version', String
+
+    ##
     # The root URI for the NCS Navigator Core deployment in this instance of
     # the suite.
     configuration_attribute :core_uri, 'Core', 'uri', URI
@@ -307,6 +311,7 @@ module NcsNavigator
     section_accessor 'Staff Portal', :staff_portal
     section_accessor 'Core', :core
     section_accessor 'PSC', :psc
+    section_accessor 'Pancakes', :pancakes
 
     ##
     # Creates a new Configuration.

--- a/sample_configuration.ini
+++ b/sample_configuration.ini
@@ -80,6 +80,27 @@ uri = "https://staffportal.greaterchicagoncs.org/"
 # appear to come.
 mail_from = "staffportal@greaterchicagoncs.org"
 
+[Pancakes]
+# Configuration options used by NCS Navigator Pancakes.
+#
+# Pancakes is an optional component of the NCS Navigator suite, so all
+# of these attributes are optional _from the perspective of this
+# library_.  However, some of these attributes are required for Pancakes
+# startup.  Those attributes are flagged as such.
+
+# The MDES version that will be used by Pancakes for reading code lists
+# and the like.  Required for startup.
+#
+# Note: this only applies to a Pancakes instance, not the entire NCS
+# Navigator suite.  Cases and Ops do much more with the MDES than
+# Pancakes does, and require specific migration processes to change from
+# one MDES version to another.
+#
+# If you're involved in an NCS Navigator deployment, you SHOULD make
+# sure that a Pancakes instance uses the same MDES version as its
+# corresponding Ops and Cases instances.
+mdes_version = '3.2'
+
 [Core]
 # Configuration options which are used by or which describe NCS
 # Navigator Core in this instance of the suite.

--- a/spec/ncs_navigator/configuration_spec.rb
+++ b/spec/ncs_navigator/configuration_spec.rb
@@ -107,6 +107,19 @@ module NcsNavigator
       end
     end
 
+    describe '#pancakes_mdes_version' do
+      it 'is not mandatory' do
+        lambda { from_minimum_valid_hash }.
+          should_not raise_error
+      end
+
+      it "returns Pancakes' MDES version" do
+        input_hash['Pancakes'] = { 'mdes_version' => '3.2' }
+
+        from_hash.pancakes_mdes_version.should == '3.2'
+      end
+    end
+
     describe '#study_center_id' do
       it 'reflects the configured value' do
         from_hash.study_center_id.should == '23000000'


### PR DESCRIPTION
NUBIC/ncs_navigator_pancakes allows searching by event type.  Therefore, it needs to know what event type list (i.e. which MDES version) to use.

This pull request puts that information in the configuration library.
